### PR TITLE
fix: Correct multiple default exports after React.memo application

### DIFF
--- a/components/property/AmenitiesGrid.tsx
+++ b/components/property/AmenitiesGrid.tsx
@@ -6,7 +6,7 @@ import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { useProperty } from "./PropertyContext";
 
-export default function AmenitiesGrid() {
+function AmenitiesGrid() {
   const { property } = useProperty();
   
   const amenitiesIcons: Record<string, React.ReactNode> = {

--- a/components/property/LocationMap.tsx
+++ b/components/property/LocationMap.tsx
@@ -6,7 +6,7 @@ import { MapPin, Navigation, ExternalLink } from "lucide-react";
 import { motion } from "framer-motion";
 import { useProperty } from "./PropertyContext";
 
-export default function LocationMap() {
+function LocationMap() {
   const { property } = useProperty();
   
   return (

--- a/components/property/PropertyOverview.tsx
+++ b/components/property/PropertyOverview.tsx
@@ -7,7 +7,7 @@ import { Clock, User, Shield, Check } from "lucide-react";
 import { motion } from "framer-motion";
 import { useProperty } from "./PropertyContext";
 
-export default function PropertyOverview() {
+function PropertyOverview() {
   const { property } = useProperty();
   
   const container = {

--- a/components/property/PropertySpecifications.tsx
+++ b/components/property/PropertySpecifications.tsx
@@ -5,7 +5,7 @@ import { Separator } from "@/components/ui/separator";
 import { motion } from "framer-motion";
 import { useProperty } from "./PropertyContext";
 
-export default function PropertySpecifications() {
+function PropertySpecifications() {
   const { property } = useProperty();
   
   const container = {


### PR DESCRIPTION
Resolves a build error where components were exported with `export default function ComponentName()` and also `export default memo(ComponentName)`.

The fix involves removing `default` from the initial function declaration for the affected components:
- AmenitiesGrid.tsx
- PropertyOverview.tsx
- PropertySpecifications.tsx
- LocationMap.tsx

Other components that used `React.memo` for sub-components were already correctly structured. This change ensures a single default export per module, resolving the "Exported identifiers must be unique" error.