### PR TITLE
Here's my proposed commit message:

### DIFF
--- a/app/property/[id]/page.tsx
+++ b/app/property/[id]/page.tsx
@@ -1,5 +1,15 @@
 import React from "react";
 import PropertyPage from "@/components/property/PropertyPage";
+import { MOCK_PROPERTY_DATA } from "@/lib/mockData";
+
+export async function generateStaticParams() {
+  return [
+    { id: '123' }, // Corresponds to the demo link on the homepage
+    { id: MOCK_PROPERTY_DATA.id },
+    { id: 'property-abc' }, // Example additional ID
+    { id: 'property-xyz' }, // Example additional ID
+  ];
+}
 
 export default function Page({ params }: { params: { id: string } }) {
   return <PropertyPage id={params.id} />;


### PR DESCRIPTION
fix: Add generateStaticParams to property page for static export

Resolves a build error caused by the `output: 'export'` configuration in `next.config.js` when used with dynamic routes.

The `app/property/[id]/page.tsx` file was missing the required `generateStaticParams` function. This commit adds this function, providing a list of sample property IDs (including the one from mock data) to be pre-rendered at build time.