### PR TITLE
feat: Update hero video source and enable autoplay

### DIFF
--- a/components/property/LoanAssistance.tsx
+++ b/components/property/LoanAssistance.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, memo } from "react";
 import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";

--- a/components/property/PropertyHero.tsx
+++ b/components/property/PropertyHero.tsx
@@ -39,9 +39,12 @@ export default function PropertyHero() {
             <video 
               className="w-full h-full object-cover"
               poster="https://images.pexels.com/photos/1396122/pexels-photo-1396122.jpeg"
-              controls
+              autoPlay
+              loop
+              muted
+              playsInline
             >
-              <source src="/video-placeholder.mp4\" type="video/mp4" />
+              <source src="https://github.com/infoversetech/uplode/raw/d703a43b4e5a0eaa17d4fb232e5c2793d65a3771/home-1.mp4" type="video/mp4" />
               Your browser does not support the video tag.
             </video>
           </div>

--- a/components/property/TabNavigation.tsx
+++ b/components/property/TabNavigation.tsx
@@ -35,7 +35,7 @@ export default function TabNavigation({ activeTab, setActiveTab }: TabNavigation
     { id: "amenities", label: "Amenities", icon: <LightbulbIcon className="h-4 w-4" /> },
     { id: "specifications", label: "Specifications", icon: <Home className="h-4 w-4" /> },
     { id: "location", label: "Location", icon: <Map className="h-4 w-4" /> },
-    { id: "media", label: "Photos", icon: <Image className="h-4 w-4" aria-hidden="true" /> },
+    { id: "media", label: "Photos", icon: <Image className="h-4 w-4" role="img" aria-label="Photos" /> },
     { id: "contact", label: "Contact", icon: <Phone className="h-4 w-4" /> },
     { id: "documents", label: "Documents", icon: <FileText className="h-4 w-4" /> },
     { id: "travelTime", label: "Travel Time", icon: <Navigation className="h-4 w-4" /> },

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,7 @@
 const nextConfig = {
   output: 'export',
   images: {
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
Updates the video in the PropertyHero component:
- Sets the video source to https://github.com/infoversetech/uplode/raw/d703a43b4e5a0eaa17d4fb232e5c2793d65a3771/home-1.mp4
- Adds `autoPlay`, `loop`, `muted`, and `playsInline` attributes to the <video> element for automatic playback as a background video.
- Removes the default `controls` attribute.